### PR TITLE
Remove "Gem.clear_path" since it is not working in OpsWorks context

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -30,8 +30,6 @@ chef_gem "zk" do
   action :nothing
 end.run_action(:install)
 
-Gem.clear_paths
-
 require 'zk'
 require 'net/http'
 require 'json'


### PR DESCRIPTION
Pull request to remove Gem.clear_path since this fails on AWS OpsWorks
