### PR TITLE
Possiblity to overwrite default node attributes on runtime

### DIFF
--- a/recipes/collections.rb
+++ b/recipes/collections.rb
@@ -29,6 +29,10 @@ node['solrcloud']['collections'].each { |collection_name, options|
     router_name     options[:router_name]
     router_field    options[:router_field]
     use_ssl         options[:use_ssl]
+    zkhost          options[:zkhost]    || node['solrcloud']['solr_config']['solrcloud']['zk_host'].first
+    zkcli           options[:zkcli]     || node['solrcloud']['zookeeper']['zkcli']
+    port            options[:port]      || node['solrcloud']['port']
+    ssl_port        options[:ssl_port]  || node['solrcloud']['ssl_port']
     create_node_set         options[:create_node_set]
     replication_factor      options[:replication_factor]
     max_shards_per_node     options[:max_shards_per_node]

--- a/recipes/zkconfigsets.rb
+++ b/recipes/zkconfigsets.rb
@@ -20,14 +20,14 @@
 node['solrcloud']['zkconfigsets'].each { |configset_name, options|
 
   solrcloud_zkconfigset configset_name do
-    user      options[:user]
-    group     options[:group]
-    zkcli     options[:zkcli]
-    zkhost    options[:zkhost]
-    zkconfigsets_home       options[:zkconfigsets_home]
-    zkconfigsets_cookbook   options[:zkconfigsets_cookbook]
-    manage_zkconfigsets     options[:manage_zkconfigsets]
-    solr_zkcli              options[:solr_zkcli]
+    user      options[:user]  || node['solrcloud']['user']
+    group     options[:group] || node['solrcloud']['group']
+    zkcli     options[:zkcli] || node['solrcloud']['zookeeper']['zkcli']
+    zkhost    options[:zkhost]|| node['solrcloud']['solr_config']['solrcloud']['zk_host'].first
+    zkconfigsets_home       options[:zkconfigsets_home]     || node['solrcloud']['zkconfigsets_home']
+    zkconfigsets_cookbook   options[:zkconfigsets_cookbook] || node['solrcloud']['zkconfigsets_cookbook']
+    manage_zkconfigsets     options[:manage_zkconfigsets]   || node['solrcloud']['manage_zkconfigsets']
+    solr_zkcli              options[:solr_zkcli]            || node['solrcloud']['zookeeper']['solr_zkcli']
     action    options[:action]
   end
 


### PR DESCRIPTION
When you want to set the node attributes on runtime and use them we can check if the relevant options node is nil and pass the default to use the runtime value,
when no option is passed.
