### PR TITLE
Removed chef prefix to allow kitchen to find ISOs.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,8 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: chef/ubuntu-14.04
-  - name: chef/centos-6.5
+  - name: ubuntu-14.04
+  - name: centos-6.5
 
 suites:
   - name: default


### PR DESCRIPTION
I verified the kitchen images are building now from fresh images. Where did the ```chef/``` prefix come from though? I get errors about not being able to find the ISOs with it. Fixes #45 