### PR TITLE
Allow solr to start using new SystemV for version 5.2.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,6 @@
 ---
 driver:
   name: vagrant
-  network:
-    - ["forwarded_port", {guest: 8983, host: 8888}]
 
 provisioner:
   name: chef_solo
@@ -12,10 +10,19 @@ platforms:
   - name: chef/centos-6.5
 
 suites:
-  - name: default
+  - name: 5.1.0
     run_list:
       - recipe[solrcloud_test::prerun]
       - recipe[solrcloud::default]
     attributes:
       solrcloud:
+        version: 5.1.0
+        zk_run: true
+  - name: 5.2.0
+    run_list:
+      - recipe[solrcloud_test::prerun]
+      - recipe[solrcloud::default]
+    attributes:
+      solrcloud:
+        version: 5.2.0
         zk_run: true

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'foodcritic'
 gem 'rubocop'
 # gem 'vagrant-berkshelf'
 
+gem 'busser-serverspec'
+gem 'serverspec'
 # gem 'fauxhai'
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -343,9 +343,13 @@ Parameters:
 
         With attribute `default[:solrcloud][:zk_run]`, this attribute will get local zookeeper server.
 
- * `default[:solrcloud][:java_options]` (default: `[]`): java options
+ * `default[:solrcloud][:java_options]` (default: `[]`): java options. Note that xmx and xms have special attributes and setting them through this list will not work past SOLR v.5.2.x.
 
- * `default[:solrcloud][:auto_java_memory]` (default: `true`): enable auto java memory allocation, sets java attribute `-Xmx` for `node[:solrcloud][:java_options]`
+ * `default[:solrcloud][:java_xmx]` (default: `512m`): Default starting memory for the JVM unless auto_java_memory is turned on in which case the default is dynamically defined.
+
+ * `default[:solrcloud][:java_xms]` (default: `512m`): Default starting memory for the JVM unless auto_java_memory is turned on in which case the default is dynamically defined.
+
+ * `default[:solrcloud][:auto_java_memory]` (default: `true`): enable auto java memory allocation, sets dynamic defaults for node attributes `node[:solrcloud][:java_xms]` and `node[:solrcloud][:java_xms]`.
 
 		This option calculates maximum allowed memory (multiple of 1024) for java process with minimum system memory 		reservation defined by attribute `node[:solrcloud][:auto_system_memory]`
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Parameters:
 
  * `default[:solrcloud][:solr_home]` (default: `node[:solrcloud][:install_dir]/solr`): solr home
 
+ * `default[:solrcloud][:sysconfig_file]` (default: ```{ debian: '/etc/default/solr', rhel: '/etc/sysconfig/solr' }```): Location of sysconfig file meant for assigning environment variables to solr on startup.
+
  * `default[:solrcloud][:cores_home]` (default: `node[:solrcloud][:solr_home]/cores`): solr collection/core home
 
  * `default[:solrcloud][:shared_lib]` (default: `node[:solrcloud][:install_dir]`/lib): solr default lib directory

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,10 @@ default['solrcloud']['server_base_dir_name'] = node['solrcloud']['major_version'
 
 default['solrcloud']['install_dir']   = '/usr/local/solr'
 default['solrcloud']['data_dir']      = '/opt/solr'
+default['solrcloud']['sysconfig_file'] = value_for_platform_family(
+  'debian' => '/etc/default/solr',
+  'rhel' => '/etc/sysconfig/solr'
+)
 
 default['solrcloud']['restore_cores'] = true
 

--- a/attributes/memory.rb
+++ b/attributes/memory.rb
@@ -22,5 +22,9 @@ if node['solrcloud']['auto_java_memory'] && node['memory'] && node['memory'].key
   java_memory = total_memory - system_memory
   # Making Java -Xmx even
   java_memory += 1 unless java_memory.even?
-  node.default['solrcloud']['java_options'] << " -Xmx#{java_memory}m "
+  default['solrcloud']['java_xmx'] = "#{java_memory}m"
+  default['solrcloud']['java_xms'] = "#{java_memory}m"
+else
+  default['solrcloud']['java_xmx'] = '512m'
+  default['solrcloud']['java_xms'] = '512m'
 end

--- a/recipes/jetty.rb
+++ b/recipes/jetty.rb
@@ -94,37 +94,18 @@ if !File.exist?(node['solrcloud']['key_store']['key_store_file_path']) && node['
 end
 
 template 'solr_config' do
-  source 'solr.conf.erb'
+  source node['solrcloud']['version'] > '5.2' ? 'v5.2.x/solr.conf.erb' : 'solr.conf.erb'
   owner node['solrcloud']['user']
   group node['solrcloud']['group']
   mode 0744
   path node['solrcloud']['sysconfig_file']
-  only_if { node['solrcloud']['major_version'] <= 5 && node['solrcloud']['minor_version'] < 2 }
-end
-
-template 'solr_config' do
-  source 'v5.2.x/solr.conf.erb'
-  owner node['solrcloud']['user']
-  group node['solrcloud']['group']
-  mode 0744
-  path node['solrcloud']['sysconfig_file']
-  only_if { node['solrcloud']['version'] > '5.2' }
 end
 
 template '/etc/init.d/solr' do
-  source "#{node['platform_family']}.solr.init.erb"
+  source node['solrcloud']['version'] > '5.2' ? 'v5.2.x/solr.init.erb' : "#{node['platform_family']}.solr.init.erb"
   owner node['solrcloud']['user']
   group node['solrcloud']['group']
   mode 0744
-  only_if { node['solrcloud']['major_version'] <= 5 && node['solrcloud']['minor_version'] < 2 }
-end
-
-template '/etc/init.d/solr' do
-  source 'v5.2.x/solr.init.erb'
-  owner node['solrcloud']['user']
-  group node['solrcloud']['group']
-  mode 0744
-  only_if { node['solrcloud']['version'] > '5.2' }
 end
 
 template node['solrcloud']['jmx']['access_file'] do

--- a/recipes/jetty.rb
+++ b/recipes/jetty.rb
@@ -93,19 +93,12 @@ if !File.exist?(node['solrcloud']['key_store']['key_store_file_path']) && node['
   end
 end
 
-solr_config_path =  case node['platform_family']
-                    when 'rhel'
-                      '/etc/sysconfig/solr'
-                    when 'debian'
-                      '/etc/default/solr'
-                    end
-
 template 'solr_config' do
   source 'solr.conf.erb'
   owner node['solrcloud']['user']
   group node['solrcloud']['group']
   mode 0744
-  path solr_config_path
+  path node['solrcloud']['sysconfig_file']
   only_if { node['solrcloud']['major_version'] <= 5 && node['solrcloud']['minor_version'] < 2 }
 end
 
@@ -114,7 +107,7 @@ template 'solr_config' do
   owner node['solrcloud']['user']
   group node['solrcloud']['group']
   mode 0744
-  path solr_config_path
+  path node['solrcloud']['sysconfig_file']
   only_if { node['solrcloud']['version'] > '5.2' }
 end
 
@@ -131,7 +124,6 @@ template '/etc/init.d/solr' do
   owner node['solrcloud']['user']
   group node['solrcloud']['group']
   mode 0744
-  variables solr_env: solr_config_path
   only_if { node['solrcloud']['version'] > '5.2' }
 end
 

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -31,7 +31,6 @@ end
 
 chef_gem 'zk' do
   action :install
-  compile_time false
   only_if { node['solrcloud']['install_zk_gem'] }
 end
 

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -24,15 +24,15 @@ include_recipe 'solrcloud::java'
 # Require for zk gem
 %w(patch gcc).each do |pkg|
   package pkg do
-    action :install
+    action :nothing
     only_if { node['solrcloud']['install_zk_gem'] }
-  end
+  end.run_action(:install)
 end
 
 chef_gem 'zk' do
-  action :install
+  action :nothing
   only_if { node['solrcloud']['install_zk_gem'] }
-end
+end.run_action(:install)
 
 require 'net/http'
 require 'json'

--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -24,17 +24,17 @@ include_recipe 'solrcloud::java'
 # Require for zk gem
 %w(patch gcc).each do |pkg|
   package pkg do
-    action :nothing
+    action :install
     only_if { node['solrcloud']['install_zk_gem'] }
-  end.run_action(:install)
+  end
 end
 
 chef_gem 'zk' do
-  action :nothing
+  action :install
+  compile_time false
   only_if { node['solrcloud']['install_zk_gem'] }
-end.run_action(:install)
+end
 
-require 'zk'
 require 'net/http'
 require 'json'
 require 'tmpdir'

--- a/templates/default/solr.conf.erb
+++ b/templates/default/solr.conf.erb
@@ -11,8 +11,8 @@ JAVA_OPTIONS="-Dsolr.solr.home=<%= node.solrcloud.solr_home %> \
 -Dsolr.directoryFactory=<%= node.solrcloud.hdfs.directory_factory %> \
 -Dsolr.lock.type=<%= node.solrcloud.hdfs.lock_type %> \
 -Dsolr.hdfs.home=<%= node.solrcloud.hdfs.hdfs_home %> \
-<%end-%>
-<%if node.solrcloud.enable_jmx-%>
+<% end -%>
+<% if node.solrcloud.enable_jmx -%>
 -Dcom.sun.management.jmxremote \
 -Dcom.sun.management.jmxremote.local.only=false \
 -Dcom.sun.management.jmxremote.port=<%= node.solrcloud.jmx.port %> \
@@ -22,15 +22,14 @@ JAVA_OPTIONS="-Dsolr.solr.home=<%= node.solrcloud.solr_home %> \
 -Dcom.sun.management.jmxremote.access.file=<%= node.solrcloud.jmx.access_file %> \
 -Djava.rmi.server.hostname=<%= node.ipaddress %> \
 <% end -%>
-<%= node.solrcloud.java_options.join(' ') %> \
+<% if node.solrcloud.java_options.find { |jo| jo.match /Xmx\d+/ }.nil? -%>
+-Xmx<%= node.solrcloud.java_xmx %> \
+<% end -%>
+<% if node.solrcloud.java_options.find { |jo| jo.match /Xms\d+/ }.nil? -%>
+-Xms<%= node.solrcloud.java_xms %> \
+<% end -%>
+<%= node.solrcloud.java_options.join(' \/n') -%>
 $JAVA_OPTIONS \
-<% if node.solrcloud.major_version == 5 && node.solrcloud.minor_version > 1 -%>
-<% if node.solrcloud.enable_ssl -%>
---module=https \
-<% else %>
---module=http \
-<% end -%>
-<% end -%>
 "
 
 JETTY_HOME=<%=node.solrcloud.install_dir%>

--- a/templates/default/v5.2.x/solr.conf.erb
+++ b/templates/default/v5.2.x/solr.conf.erb
@@ -1,0 +1,136 @@
+#
+# This file is managed by Chef.
+# Do NOT modify this file directly.
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# By default the script will use JAVA_HOME to determine which java
+# to use, but you can set a specific path for Solr to use without
+# affecting other Java applications on your server/workstation.
+#SOLR_JAVA_HOME=""
+
+# Increase Java Heap as needed to support your indexing / query needs
+# SOLR_HEAP="512m"
+
+# Expert: If you want finer control over memory options, specify them directly
+# Comment out SOLR_HEAP if you are using this though, that takes precedence
+SOLR_JAVA_MEM="-Xms<%= node.solrcloud.java_xms %> -Xmx<%= node.solrcloud.java_xmx %>"
+
+# Enable verbose GC logging
+GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
+
+# These GC settings have shown to work well for a number of common Solr workloads
+GC_TUNE="-XX:NewRatio=3 \
+-XX:SurvivorRatio=4 \
+-XX:TargetSurvivorRatio=90 \
+-XX:MaxTenuringThreshold=8 \
+-XX:+UseConcMarkSweepGC \
+-XX:+UseParNewGC \
+-XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 \
+-XX:+CMSScavengeBeforeRemark \
+-XX:PretenureSizeThreshold=64m \
+-XX:+UseCMSInitiatingOccupancyOnly \
+-XX:CMSInitiatingOccupancyFraction=50 \
+-XX:CMSMaxAbortablePrecleanTime=6000 \
+-XX:+CMSParallelRemarkEnabled \
+-XX:+ParallelRefProcEnabled"
+
+# Set the ZooKeeper connection string if using an external ZooKeeper ensemble
+# e.g. host1:2181,host2:2181/chroot
+# Leave empty if not using SolrCloud
+ZK_HOST="<%= node['solrcloud']['solr_config']['solrcloud']['zk_host'].map do |zk_host|
+  "#{zk_host}#{node['solrcloud']['solr_config']['solrcloud']['zk_chroot']}"
+end.join(',') %>"
+
+# Set the ZooKeeper client timeout (for SolrCloud mode)
+ZK_CLIENT_TIMEOUT="<%= node['solrcloud']['solr_config']['solrcloud']['zk_client_timeout'] %>"
+
+# By default the start script uses "localhost"; override the hostname here
+# for production SolrCloud environments to control the hostname exposed to cluster state
+#SOLR_HOST="192.168.1.1"
+
+# By default the start script uses UTC; override the timezone if needed
+#SOLR_TIMEZONE="UTC"
+
+# Set to true to activate the JMX RMI connector to allow remote JMX client applications
+# to monitor the JVM hosting Solr; set to "false" to disable that behavior
+# (false is recommended in production environments)
+ENABLE_REMOTE_JMX_OPTS="<%= node.solrcloud.enable_jmx ? "true" : "false" %>"
+
+# The script will use SOLR_PORT+10000 for the RMI_PORT or you can set it here
+RMI_PORT=<%= node.solrcloud.jmx.port %>
+
+# Anything you add to the SOLR_OPTS variable will be included in the java
+# start command line as-is, in ADDITION to other options. If you specify the
+# -a option on start script, those options will be appended as well.
+<% if node.solrcloud.hdfs.enable and node.solrcloud.hdfs.hdfs_home -%>
+SOLR_OPTS="$SOLR_OPTS -Dsolr.directoryFactory=<%= node.solrcloud.hdfs.directory_factory %>"
+SOLR_OPTS="$SOLR_OPTS -Dsolr.lock.type=<%= node.solrcloud.hdfs.lock_type %>"
+SOLR_OPTS="$SOLR_OPTS -Dsolr.hdfs.home=<%= node.solrcloud.hdfs.hdfs_home %>"
+<%end-%>
+
+<% if node.solrcloud.enable_jmx -%>
+SOLR_OPTS="$SOLR_OPTS \
+-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.local.only=false \
+-Dcom.sun.management.jmxremote.ssl=false \
+-Dcom.sun.management.jmxremote.authenticate=<%= node.solrcloud.jmx.authenticate %> \
+-Dcom.sun.management.jmxremote.password.file=<%= node.solrcloud.jmx.password_file %> \
+-Dcom.sun.management.jmxremote.access.file=<%= node.solrcloud.jmx.access_file %> \
+-Djava.rmi.server.hostname=<%= node.ipaddress %> \
+"
+<% end -%>
+
+# Location where the bin/solr script will save PID files for running instances
+# If not set, the script will create PID files in $SOLR_TIP/bin
+SOLR_PID_DIR=<%= node.solrcloud.pid_dir %>
+
+# Path to a directory where Solr creates index files, the specified directory
+# must contain a solr.xml; by default, Solr will use server/solr
+SOLR_HOME=<%= node.solrcloud.solr_home %>
+
+# Solr provides a default Log4J configuration properties file in server/resources
+# however, you may want to customize the log settings and file appender location
+# so you can point the script to use a different log4j.properties file
+LOG4J_PROPS=<%= File.join(node['solrcloud']['install_dir'], 'resources', 'log4j.properties') %>
+
+# Location where Solr should write logs to; should agree with the file appender
+# settings in server/resources/log4j.properties
+SOLR_LOGS_DIR=<%= node.solrcloud.log_dir %>
+
+# Sets the port Solr binds to, default is 8983
+SOLR_PORT=<%= node.solrcloud.port %>
+
+# Uncomment to set SSL-related system properties
+# Be sure to update the paths to the correct keystore for your environment
+#SOLR_SSL_KEY_STORE=etc/solr-ssl.keystore.jks
+#SOLR_SSL_KEY_STORE_PASSWORD=secret
+#SOLR_SSL_TRUST_STORE=etc/solr-ssl.keystore.jks
+#SOLR_SSL_TRUST_STORE_PASSWORD=secret
+#SOLR_SSL_NEED_CLIENT_AUTH=false
+#SOLR_SSL_WANT_CLIENT_AUTH=false
+
+# Uncomment if you want to override previously defined SSL values for HTTP client
+# otherwise keep them commented and the above values will automatically be set for HTTP clients
+#SOLR_SSL_CLIENT_KEY_STORE=
+#SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
+#SOLR_SSL_CLIENT_TRUST_STORE=
+#SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD=
+
+# Settings for authentication
+#SOLR_AUTHENTICATION_CLIENT_CONFIGURER=
+#SOLR_AUTHENTICATION_OPTS=

--- a/templates/default/v5.2.x/solr.init.erb
+++ b/templates/default/v5.2.x/solr.init.erb
@@ -48,7 +48,7 @@ fi
 # variables used by the bin/solr script. It's highly recommended to define this script so
 # that you can keep the Solr binary files separated from live files (pid, logs, index data, etc)
 # see bin/solr.in.sh for an example
-SOLR_ENV=<%= @solr_env %>
+SOLR_ENV=<%= node['solrcloud']['sysconfig_file'] %>
 
 if [ ! -f "$SOLR_ENV" ]; then
   echo "$SOLR_ENV not found! Please check the SOLR_ENV setting in your $0 script."

--- a/templates/default/v5.2.x/solr.init.erb
+++ b/templates/default/v5.2.x/solr.init.erb
@@ -1,0 +1,82 @@
+#!/bin/sh
+#
+# This file is managed by Chef.
+# Do NOT modify this file directly.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### BEGIN INIT INFO
+# Provides:          solr
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       Controls Apache Solr as a Service
+### END INIT INFO
+
+# Example of a very simple *nix init script that delegates commands to the bin/solr script
+# Typical usage is to do:
+#
+#   cp bin/init.d/solr /etc/init.d/solr
+#   chmod 755 /etc/init.d/solr
+#   chown root:root /etc/init.d/solr
+#   update-rc.d solr defaults
+#   update-rc.d solr enable
+
+# Where you extracted the Solr distribution bundle
+SOLR_INSTALL_DIR=<%= node.solrcloud.install_dir %>
+
+if [ ! -d "$SOLR_INSTALL_DIR" ]; then
+  echo "$SOLR_INSTALL_DIR not found! Please check the SOLR_INSTALL_DIR setting in your $0 script."
+  exit 1
+fi
+
+# Path to an include file that defines environment specific settings to override default
+# variables used by the bin/solr script. It's highly recommended to define this script so
+# that you can keep the Solr binary files separated from live files (pid, logs, index data, etc)
+# see bin/solr.in.sh for an example
+SOLR_ENV=<%= @solr_env %>
+
+if [ ! -f "$SOLR_ENV" ]; then
+  echo "$SOLR_ENV not found! Please check the SOLR_ENV setting in your $0 script."
+  exit 1
+fi
+
+# Specify the user to run Solr as; if not set, then Solr will run as root.
+# Running Solr as root is not recommended for production environments
+RUNAS=<%= node.solrcloud.user %>
+
+# verify the specified run as user exists
+runas_uid=`id -u $RUNAS`
+if [ $? -ne 0 ]; then
+  echo "User $RUNAS not found! Please create the $RUNAS user before running this script."
+  exit 1
+fi
+
+case "$1" in
+  start|stop|restart|status)
+    SOLR_CMD=$1
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit
+esac
+
+if [ -n "$RUNAS" ]; then
+  su -c "SOLR_INCLUDE=$SOLR_ENV $SOLR_INSTALL_DIR/bin/solr $SOLR_CMD" - $RUNAS
+else
+  SOLR_INCLUDE=$SOLR_ENV $SOLR_INSTALL_DIR/bin/solr $SOLR_CMD
+fi

--- a/test/integration/5.1.0/serverspec/solr_spec.rb
+++ b/test/integration/5.1.0/serverspec/solr_spec.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe 'Working SOLR node' do
+  it 'is listening on port 8928' do
+    expect(port(8983)).to be_listening
+  end
+
+  it 'has a running solr service' do
+    expect(service('solr')).to be_running
+  end
+end

--- a/test/integration/5.2.0/serverspec/solr_spec.rb
+++ b/test/integration/5.2.0/serverspec/solr_spec.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe 'Working SOLR node' do
+  it 'is listening on port 8928' do
+    expect(port(8983)).to be_listening
+  end
+
+  it 'has a running solr service' do
+    expect(service('solr')).to be_running
+  end
+end


### PR DESCRIPTION
Fixed #37 and added integration tests that can be run with `kitchen verify` to make sure solr is running properly after successful convergence. Should be enough to close #46. I feel quite confident that the cookbook will work with the tests in place.