### PR TITLE
Added missing dependency (make) to build zk gem

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -22,7 +22,7 @@ include_recipe 'solrcloud::user'
 include_recipe 'solrcloud::java'
 
 # Require for zk gem
-%w(patch gcc).each do |pkg|
+%w(patch gcc make).each do |pkg|
   package pkg do
     action :nothing
     only_if { node['solrcloud']['install_zk_gem'] }


### PR DESCRIPTION
When running `solrcloud::tarball` for the first time on the system, it failed with an error:
```
  * chef_gem[zk] action install

    ================================================================================
    Error executing action `install` on resource 'chef_gem[zk]'
    ================================================================================

    Mixlib::ShellOut::ShellCommandFailed
    ------------------------------------
    Expected process to exit with [0], but received '1'
    ---- Begin output of /opt/chef/embedded/bin/gem install zk -q --no-rdoc --no-ri -v "1.9.5" ----
    STDOUT: Building native extensions.  This could take a while...
    STDERR: ERROR:  Error installing zk:
    	ERROR: Failed to build gem native extension.
[...]
make  2>&1
    sh: 1: make: not found
    *** extconf.rb failed ***
    Could not create Makefile due to some reason, probably lack of
    necessary libraries and/or headers.  Check the mkmf.log file for more
    details.  You may need configuration options.

```

Installing `make` on the system helped, hence I am submitting this PR.
