### PR TITLE
Allow download url to be modified via chef attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,37 @@ default['solrcloud']['setup_user']    = true # ideally it must be set to false f
 
 default['solrcloud']['version']       = '5.1.0'
 
+default['solrcloud']['solr']['url']   = {
+    '4.9.0' => "https://archive.apache.org/dist/lucene/solr/4.9.0/solr-4.9.0.tgz",
+    '4.9.1' => "https://archive.apache.org/dist/lucene/solr/4.9.1/solr-4.9.1.tgz",
+    '4.10.0' => "https://archive.apache.org/dist/lucene/solr/4.10.0/solr-4.10.0.tgz",
+    '4.10.1' => "https://archive.apache.org/dist/lucene/solr/4.10.1/solr-4.10.1.tgz",
+    '4.10.2' => "https://archive.apache.org/dist/lucene/solr/4.10.2/solr-4.10.2.tgz",
+    '4.10.3' => "https://archive.apache.org/dist/lucene/solr/4.10.3/solr-4.10.3.tgz",
+    '4.10.4' => "https://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz",
+    '5.0.0' => "https://archive.apache.org/dist/lucene/solr/5.0.0/solr-5.0.0.tgz",
+    '5.1.0' => "https://archive.apache.org/dist/lucene/solr/5.1.0/solr-5.1.0.tgz",
+    '5.2.0' => "https://archive.apache.org/dist/lucene/solr/5.2.0/solr-5.2.0.tgz",
+    '5.2.1' => "https://archive.apache.org/dist/lucene/solr/5.2.1/solr-5.2.1.tgz",
+    '5.3.0' => "https://archive.apache.org/dist/lucene/solr/5.3.0/solr-5.3.0.tgz",
+    '5.3.1' => "https://archive.apache.org/dist/lucene/solr/5.3.1/solr-5.3.1.tgz"
+}
+default['solrcloud']['solr']['checksum'] = {
+    '4.9.0' => 'c42b1251f44f8e1b826d89c362b43dec4dd9094e6a07f2f1c27e990f8c6eafdc', 
+    '4.9.1' => 'd03e9daf33df80bae4a37f88525fe19084a4502e8b38a02d7a60e2bc436076e8', 
+    '4.10.0' => '0c9c3e03b42e6afd9a2fea97a1fe2078640e97342b8b53e47df8207670661e9f',
+    '4.10.1' => '3e6359f4227f17cda7dc280bc32572a514f330dada80539b0b47dba107672563', 
+    '4.10.2' => '101bc6b02ac637ac09959140a341e6b02d8409f3f84c37b36c7628c6f8739c1f', 
+    '4.10.3' => 'ac7024a0a759c6c53cc3a66b3a84757d599d350f491eb221160613356532e2b6',
+    '4.10.4' => 'ac3543880f1b591bcaa962d7508b528d7b42e2b5548386197940b704629ae851', 
+    '5.0.0' => '48c77aede40fceda73cf4e13e08e328899685446f80f76f2e893eaffea714297', 
+    '5.1.0' => '8718cbfb789a170d210b0b4adbe4fd8187ecdc67c5348ed9d551578087d8a628',
+    '5.2.0' => 'dff2c5df505b732e23178e8f12e817dba4a088a8afe6599dcacf9ea241f76a1e', 
+    '5.2.1' => '3f54cec862da1376857f96f4a6f2044a5addcebc4df159b8797fd71f7ba8df86', 
+    '5.3.0' => '26aec63d81239a65f182f17bbf009b1070f7db0bb83657ac2a67a08b57227f7c',
+    '5.3.1' => '34ddcac071226acd6974a392af7671f687990aa1f9eb4b181d533ca6dca6f42d'
+}
+
 default['solrcloud']['tarball_purge'] = false # purge old installed archive
 
 # set default heap size = (total_memory/2)
@@ -192,3 +223,7 @@ default['solrcloud']['solr_config']['solrcloud']['host_port']   = node['solrclou
 # Only Setup Zookeeper for Client zkCli.sh.
 #
 default['solrcloud']['zookeeper']['version'] = '3.4.6'
+default['solrcloud']['zookeeper']['url'] = "https://archive.apache.org/dist/zookeeper/zookeeper-#{node['solrcloud']['zookeeper']['version']}/zookeeper-#{node['solrcloud']['zookeeper']['version']}.tar.gz"
+default['solrcloud']['zookeeper']['checksum'] = {
+    '3.4.6' => '01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994'
+}

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -3,23 +3,13 @@ def boolean_string(option)
 end
 
 def solr_tarball_sha256sum(version)
-  sha256sums = {
-    '4.9.0' => 'c42b1251f44f8e1b826d89c362b43dec4dd9094e6a07f2f1c27e990f8c6eafdc', '4.9.1' => 'd03e9daf33df80bae4a37f88525fe19084a4502e8b38a02d7a60e2bc436076e8', '4.10.0' => '0c9c3e03b42e6afd9a2fea97a1fe2078640e97342b8b53e47df8207670661e9f',
-    '4.10.1' => '3e6359f4227f17cda7dc280bc32572a514f330dada80539b0b47dba107672563', '4.10.2' => '101bc6b02ac637ac09959140a341e6b02d8409f3f84c37b36c7628c6f8739c1f', '4.10.3' => 'ac7024a0a759c6c53cc3a66b3a84757d599d350f491eb221160613356532e2b6',
-    '4.10.4' => 'ac3543880f1b591bcaa962d7508b528d7b42e2b5548386197940b704629ae851', '5.0.0' => '48c77aede40fceda73cf4e13e08e328899685446f80f76f2e893eaffea714297', '5.1.0' => '8718cbfb789a170d210b0b4adbe4fd8187ecdc67c5348ed9d551578087d8a628',
-    '5.2.0' => 'dff2c5df505b732e23178e8f12e817dba4a088a8afe6599dcacf9ea241f76a1e', '5.2.1' => '3f54cec862da1376857f96f4a6f2044a5addcebc4df159b8797fd71f7ba8df86', '5.3.0' => '26aec63d81239a65f182f17bbf009b1070f7db0bb83657ac2a67a08b57227f7c',
-    '5.3.1' => '34ddcac071226acd6974a392af7671f687990aa1f9eb4b181d533ca6dca6f42d'
-  }
-  sha256sum = sha256sums[version]
+  sha256sum = node['solrcloud']['solr']['checksum'][version]
   fail "sha256sum is missing for solr tarball version #{version}" unless sha256sum
   sha256sum
 end
 
 def zookeeper_tarball_sha256sum(version)
-  sha256sums = {
-    '3.4.6' => '01b3938547cd620dc4c93efe07c0360411f4a66962a70500b163b59014046994'
-  }
-  sha256sum = sha256sums[version]
+  sha256sum = node['solrcloud']['zookeeper']['checksum'][version]
   fail "sha256sum is missing for zookeeper tarball version #{version}" unless sha256sum
   sha256sum
 end

--- a/recipes/zkcli.rb
+++ b/recipes/zkcli.rb
@@ -22,18 +22,19 @@
 
 require 'tmpdir'
 
-zookeeper_tarball_url = "https://archive.apache.org/dist/zookeeper/zookeeper-#{node['solrcloud']['zookeeper']['version']}/zookeeper-#{node['solrcloud']['zookeeper']['version']}.tar.gz"
-zookeeper_tarball_checksum = zookeeper_tarball_sha256sum(node['solrcloud']['zookeeper']['version'])
+zookeeper_version = node['solrcloud']['zookeeper']['version']
+zookeeper_tarball_url = node['solrcloud']['zookeeper']['url']
+zookeeper_tarball_checksum = zookeeper_tarball_sha256sum(zookeeper_version)
 
 temp_d        = Dir.tmpdir
-tarball_file  = ::File.join(temp_d, "zookeeper-#{node['solrcloud']['zookeeper']['version']}.tar.gz")
-tarball_dir   = ::File.join(temp_d, "zookeeper-#{node['solrcloud']['zookeeper']['version']}")
+tarball_file  = ::File.join(temp_d, "zookeeper-#{zookeeper_version}.tar.gz")
+tarball_dir   = ::File.join(temp_d, "zookeeper-#{zookeeper_version}")
 
 # Zookeeper Version Package File
 remote_file tarball_file do
   source zookeeper_tarball_url
   checksum zookeeper_tarball_checksum
-  not_if { ::File.exist?("#{node['solrcloud']['zookeeper']['source_dir']}/zookeeper-#{node['solrcloud']['zookeeper']['version']}.jar") }
+  not_if { ::File.exist?("#{node['solrcloud']['zookeeper']['source_dir']}/zookeeper-#{zookeeper_version}.jar") }
 end
 
 # Extract and Setup Zookeeper Source directories
@@ -49,7 +50,7 @@ bash 'extract_zookeeper_tarball' do
   EOS
 
   not_if  { ::File.exist?(node['solrcloud']['zookeeper']['source_dir']) }
-  creates "#{node['solrcloud']['zookeeper']['install_dir']}/zookeeper-#{node['solrcloud']['zookeeper']['version']}.jar"
+  creates "#{node['solrcloud']['zookeeper']['install_dir']}/zookeeper-#{zookeeper_version}.jar"
   action :run
 end
 


### PR DESCRIPTION
This Pull Request is to modify the cookbook to allow the capability of overriding the download url, so that the tarballs for Apache Solr and Apache Zookeeper can be downloaded from an alternate location.
