### PR TITLE
Don't use remote_file to delete a local file

### DIFF
--- a/recipes/tarball.rb
+++ b/recipes/tarball.rb
@@ -177,7 +177,7 @@ ruby_block 'require_pam_limits.so' do
   end
 end
 
-remote_file 'local_solr_tarball_file' do
+file 'local_solr_tarball_file' do
   path tarball_file
   action :delete
 end

--- a/recipes/zkcli.rb
+++ b/recipes/zkcli.rb
@@ -83,6 +83,6 @@ template ::File.join(node['solrcloud']['zookeeper']['install_dir'], 'bin', 'zkEn
   mode 0644
 end
 
-remote_file tarball_file do
+file tarball_file do
   action :delete
 end


### PR DESCRIPTION
The remote_file resource lists "source" as a required field. Using it without it is a compile error in (at least) chef 11.16. Curiously, it does work in a version of chef 12 I tested, despite still being documented as requiring the field.

The can be reproduced by setting the chef verison in the .kitchen.yml.
    provisioner:
        require_chef_omnibus:  11.16.0

Regardless, these aren't remote files, so this patch just changes "remote_file" to "file".
